### PR TITLE
Fixed Generic_MP_Reach_Attribute

### DIFF
--- a/src/main/java/es/tid/bgp/bgp4/update/fields/pathAttributes/Generic_MP_Reach_Attribute.java
+++ b/src/main/java/es/tid/bgp/bgp4/update/fields/pathAttributes/Generic_MP_Reach_Attribute.java
@@ -10,7 +10,21 @@ public class Generic_MP_Reach_Attribute extends MP_Reach_Attribute {
 	public void encode() {
 		//Encoding  Generic MP_Reach_Attribute
 		//FIXME: SUPONEMOS lengthofNextHopNetworkAddress cero
-		pathAttributeLength = 5;
+
+		/**
+		 * Attribute length:
+		 * 	Address Family Identifier (2 octets)
+		 * 	Subsequent Address Family Identifier (1 octet)
+		 * 	Length of Next Hop Network Address (1 octet)
+		 * 	Network Address of Next Hop (variable), assuming IPv4, 4 octets //FIXME: change this in case of IPv6
+		 * 	Reserved (1 octet)
+		 * 	Total: 9 octets
+		 *
+		 * @see RFC 4760
+		 * @see es.tid.bgp.bgp4.update.fields.pathAttributes.MP_Reach_Attribute
+		 */
+
+		pathAttributeLength = 9;
 		this.setPathAttributeLength(pathAttributeLength);
 		this.bytes=new byte[this.getLength()];
 		encodeHeader();	

--- a/src/test/java/es/tid/tests/TestBGPLSMessages.java
+++ b/src/test/java/es/tid/tests/TestBGPLSMessages.java
@@ -1,10 +1,33 @@
 package es.tid.tests;
 
-public class TestBGPLSMessages {
-	
+import es.tid.bgp.bgp4.update.fields.pathAttributes.Generic_MP_Reach_Attribute;
+import es.tid.bgp.bgp4.update.fields.pathAttributes.MP_Reach_Attribute;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class TestBGPLSMessages
+{
+
 	@org.junit.Test
-	public void testBGPLSOpen (){
-		
+	public void testBGPLSOpen()
+	{
+
+	}
+
+	@Test
+	public void testMPReach()
+	{
+		MP_Reach_Attribute mp1 = new Generic_MP_Reach_Attribute();
+		mp1.encode();
+		byte[] bytesMp1 = mp1.getBytes();
+
+		MP_Reach_Attribute mp2 = new Generic_MP_Reach_Attribute(bytesMp1, 0);
+		byte[] bytesMp2 = mp2.getBytes();
+
+		Assert.assertTrue("Bytes from both messages should be equal", Arrays.equals(bytesMp1, bytesMp2));
+		Assert.assertEquals("Both MP_Reach_Attribute objects should be equal", mp1, mp2);
 	}
 
 }


### PR DESCRIPTION
Hola,

Al instanciar un objeto de la clase Generic_MP_Reach_Attribute y ejecutar el método encode:
```java
MP_Reach_Attribute mp1 = new Generic_MP_Reach_Attribute();
mp1.encode();
```

Se genera una excepción del tipo ArrayIndexOutOfBoundsException:
```java.lang.ArrayIndexOutOfBoundsException
	at java.lang.System.arraycopy(Native Method)
	at es.tid.bgp.bgp4.update.fields.pathAttributes.MP_Reach_Attribute.encodeMP_Reach_Header(MP_Reach_Attribute.java:199)
	at es.tid.bgp.bgp4.update.fields.pathAttributes.Generic_MP_Reach_Attribute.encode(Generic_MP_Reach_Attribute.java:17)
```

He modificado la clase `Generic_MP_Reach_Attribute` para reflejar un correcto valor de la longitud del campo (acorde al RFC 4760). Incluye una clase de testeo para comprobar el correcto funcionamiento.